### PR TITLE
package.json, line 8:  concurrent should be replaced by concurrently

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "lite": "lite-server",
     "postinstall": "typings install",
     "gulp": "gulp",
-    "start": "concurrent \"npm run gulp\" \"npm run lite\" ",
+    "start": "concurrently \"npm run gulp\" \"npm run lite\" ",
     "typings": "typings"
   },
   "license": "MIT",


### PR DESCRIPTION
"concurrent" command is deprecated, the replacement is "concurrently"
